### PR TITLE
Allow impersonating users when using a service account

### DIFF
--- a/lib/google/connection.rb
+++ b/lib/google/connection.rb
@@ -18,7 +18,8 @@ module Google
         :issuer => params[:client_id],
         :audience => TOKEN_URI,
         :token_credential_uri => TOKEN_URI,
-        :signing_key => params[:signing_key]
+        :signing_key => params[:signing_key],
+        :person => params[:person]
       )
       Connection.new(params, client)
     end


### PR DESCRIPTION
Passing user email through `:person` to Google::Connection.new_with_service_account allows impersonating that user and read-write access to all of their events.